### PR TITLE
Update `hostd` update instructions for Debian

### DIFF
--- a/hosting/setting-up-hostd/linux/debian.md
+++ b/hosting/setting-up-hostd/linux/debian.md
@@ -114,11 +114,24 @@ sudo systemctl start hostd
 
 ## Updating `hostd`
 
-To update `hostd` to the latest version, you can run the following command:
+New versions of `hostd` are released regularly and contain bug fixes and performance improvements.
 
+**To update:**
+
+1. Stop the `hostd` service.
+```sh
+sudo systemctl stop hostd
+```
+
+2. Upgrade `hostd` using the `apt` package manager.
 ```sh
 sudo apt update
 sudo apt upgrade hostd
+```
+
+3. Start `hostd` service.
+```sh
+sudo systemctl start hostd
 ```
 
 ## Next Steps


### PR DESCRIPTION
- Updated `hostd` upgrade instructions to stop `hostd` service before upgrade.