### PR TITLE
Remove v4Keypairs from yaml example

### DIFF
--- a/renting/setting-up-renterd/linux/other.md
+++ b/renting/setting-up-renterd/linux/other.md
@@ -212,11 +212,6 @@ http:
   password: your_api_password
 autopilot:
   heartbeat: 5m
-s3:
-  enabled: true
-  disableAuth: false
-  keypairsV4:
-    your_access_key: your_private_key
 ```
 
 Once you have added your recovery phrase and password, save the file with `ctrl+s` and exit with `ctrl+x`.
@@ -314,7 +309,7 @@ On newer versions of Linux (Ubuntu 22.04+), `sudo systemctl enable renterd` may 
 {% endhint %}
 
 Your `renterd` service should now be running. You can check the status of the service by running the following command:
-  
+
 {% tabs %}
 {% tab title="Mainnet" %}
 ```console

--- a/renting/setting-up-renterd/windows.md
+++ b/renting/setting-up-renterd/windows.md
@@ -143,11 +143,6 @@ http:
   password: your_api_password
 autopilot:
   heartbeat: 5m
-s3:
-  enabled: true
-  disableAuth: false
-  keypairsV4:
-    your_access_key: your_private_key
 ```
 
 Make sure to add your wallet seed and create an API password. The recovery phrase is the 12-word seed phrase you generated in the previous step. Type it carefully, with one space between each word, or copy it from the previous step. The password is used to unlock the `renterd` web UI; it should be something secure and easy to remember.


### PR DESCRIPTION
Fixes https://github.com/SiaFoundation/docs/issues/85

That field was removed in `v2.0.0`. Keys are now managed via the UI and S3 is enabled by default