### PR TITLE
Update host install instructions with RHP4 port

### DIFF
--- a/hosting/setting-up-hostd/linux/debian.md
+++ b/hosting/setting-up-hostd/linux/debian.md
@@ -31,7 +31,7 @@ This guide will walk you through setting up `hostd` on Linux. At the end of this
 
 To ensure you will not run into any issues with running `hostd` it is recommended your system meets the following requirements:
 
-* **Network Access:** `hostd` needs a stable internet connection and open network access in order to store and retrieve data on the Sia network. You will also need to forward the ports `9981-9983` so `hostd` can properly communicate with the network and renters.
+* **Network Access:** `hostd` needs a stable internet connection and open network access in order to store and retrieve data on the Sia network. You will also need to forward the ports `9981-9984` so `hostd` can properly communicate with the network and renters.
 
 * **Operating System Compatibility:** `hostd` is supported on the following Debian versions:
 	- Bookworm (Debian 12)

--- a/hosting/setting-up-hostd/linux/debian.md
+++ b/hosting/setting-up-hostd/linux/debian.md
@@ -31,7 +31,7 @@ This guide will walk you through setting up `hostd` on Linux. At the end of this
 
 To ensure you will not run into any issues with running `hostd` it is recommended your system meets the following requirements:
 
-* **Network Access:** `hostd` needs a stable internet connection and open network access in order to store and retrieve data on the Sia network.
+* **Network Access:** `hostd` needs a stable internet connection and open network access in order to store and retrieve data on the Sia network. You will also need to forward the ports `9981-9983` so `hostd` can properly communicate with the network and renters.
 
 * **Operating System Compatibility:** `hostd` is supported on the following Debian versions:
 	- Bookworm (Debian 12)

--- a/hosting/setting-up-hostd/linux/other.md
+++ b/hosting/setting-up-hostd/linux/other.md
@@ -28,7 +28,7 @@ This guide will walk you through setting up `hostd` on Linux. At the end of this
 
 ## Pre-requisites
 
-* **Network Access:** `hostd` needs a stable internet connection and open network access in order to store and retrieve data on the Sia network. You will also need to forward the ports `9981-9983` so `hostd` can properly communicate with the network and renters.
+* **Network Access:** `hostd` needs a stable internet connection and open network access in order to store and retrieve data on the Sia network. You will also need to forward the ports `9981-9984` so `hostd` can properly communicate with the network and renters.
 * **Operating System Compatibility:** Ensure your Linux version is compatible with the `hostd` software. To do this, run  `uname -m` in your Terminal Emulator.
 
   * **x86\_64** - `Linux AMD64`

--- a/hosting/setting-up-hostd/linux/other.md
+++ b/hosting/setting-up-hostd/linux/other.md
@@ -28,7 +28,7 @@ This guide will walk you through setting up `hostd` on Linux. At the end of this
 
 ## Pre-requisites
 
-* **Network Access:** `hostd` interacts with the Sia network, so you need a stable internet connection and open network access to connect to the Sia blockchain.
+* **Network Access:** `hostd` needs a stable internet connection and open network access in order to store and retrieve data on the Sia network. You will also need to forward the ports `9981-9983` so `hostd` can properly communicate with the network and renters.
 * **Operating System Compatibility:** Ensure your Linux version is compatible with the `hostd` software. To do this, run  `uname -m` in your Terminal Emulator.
 
   * **x86\_64** - `Linux AMD64`

--- a/hosting/setting-up-hostd/linux/ubuntu.md
+++ b/hosting/setting-up-hostd/linux/ubuntu.md
@@ -31,7 +31,7 @@ This guide will walk you through setting up `hostd` on Linux. At the end of this
 
 To ensure you will not run into any issues with running `hostd` it is recommended your system meets the following requirements:
 
-* **Network Access:** `hostd` needs a stable internet connection and open network access in order to store and retrieve data on the Sia network.
+* **Network Access:** `hostd` needs a stable internet connection and open network access in order to store and retrieve data on the Sia network. You will also need to forward the ports `9981-9983` so `hostd` can properly communicate with the network and renters.
 
 * **Operating System Compatibility:** `hostd` is supported on the following Ubuntu versions:
 	- Noble (Ubuntu 24.04)

--- a/hosting/setting-up-hostd/linux/ubuntu.md
+++ b/hosting/setting-up-hostd/linux/ubuntu.md
@@ -31,7 +31,7 @@ This guide will walk you through setting up `hostd` on Linux. At the end of this
 
 To ensure you will not run into any issues with running `hostd` it is recommended your system meets the following requirements:
 
-* **Network Access:** `hostd` needs a stable internet connection and open network access in order to store and retrieve data on the Sia network. You will also need to forward the ports `9981-9983` so `hostd` can properly communicate with the network and renters.
+* **Network Access:** `hostd` needs a stable internet connection and open network access in order to store and retrieve data on the Sia network. You will also need to forward the ports `9981-9984` so `hostd` can properly communicate with the network and renters.
 
 * **Operating System Compatibility:** `hostd` is supported on the following Ubuntu versions:
 	- Noble (Ubuntu 24.04)

--- a/hosting/setting-up-hostd/macos.md
+++ b/hosting/setting-up-hostd/macos.md
@@ -31,7 +31,7 @@ This guide will walk you through setting up `hostd` on macOS. At the end of this
 
 To ensure you will not run into any issues with running `hostd` it is recommended your system meets the following requirements:
 
-* **Network Access:** `hostd` needs a stable internet connection and open network access in order to store and retrieve data on the Sia network. You will also need to forward the ports `9981-9983` so `hostd` can properly communicate with the network and renters.
+* **Network Access:** `hostd` needs a stable internet connection and open network access in order to store and retrieve data on the Sia network. You will also need to forward the ports `9981-9984` so `hostd` can properly communicate with the network and renters.
 * **Operating System Compatibility:** `hostd` is supported on the following macOS versions:
   * macOS 12: Monterey (Star)
   * macOS 13: Ventura (Rome)

--- a/hosting/setting-up-hostd/windows.md
+++ b/hosting/setting-up-hostd/windows.md
@@ -28,7 +28,7 @@ This guide will walk you through setting up `hostd` on Windows. At the end of th
 
 ## Pre-requisites
 
-* **Network Access:** `hostd` needs a stable internet connection and open network access in order to store and retrieve data on the Sia network. You will also need to forward the ports `9981-9983` so `hostd` can properly communicate with the network and renters.
+* **Network Access:** `hostd` needs a stable internet connection and open network access in order to store and retrieve data on the Sia network. You will also need to forward the ports `9981-9984` so `hostd` can properly communicate with the network and renters.
 * **Operating System Compatibility:** Ensure your Windows version is compatible with the `hostd` software. Check [releases](../../miscellaneous/releases.md) supported by Windows versions.
 * **System Updates:** Ensure that your Windows is up to date with the latest system updates, as these updates can contain important security fixes and improvements.
 

--- a/hosting/setting-up-hostd/windows.md
+++ b/hosting/setting-up-hostd/windows.md
@@ -28,7 +28,7 @@ This guide will walk you through setting up `hostd` on Windows. At the end of th
 
 ## Pre-requisites
 
-* **Network Access:** `hostd` interacts with the Sia network, so you need a stable internet connection and open network access to connect to the Sia blockchain.
+* **Network Access:** `hostd` needs a stable internet connection and open network access in order to store and retrieve data on the Sia network. You will also need to forward the ports `9981-9983` so `hostd` can properly communicate with the network and renters.
 * **Operating System Compatibility:** Ensure your Windows version is compatible with the `hostd` software. Check [releases](../../miscellaneous/releases.md) supported by Windows versions.
 * **System Updates:** Ensure that your Windows is up to date with the latest system updates, as these updates can contain important security fixes and improvements.
 


### PR DESCRIPTION
Updates one reference to the ports that need to be opened for hosting to include the RHP4 port 9984