### PR TITLE
Consolidated port forwarding information into the `configuring-your-host` section.

### DIFF
--- a/hosting/configuring-your-host/README.md
+++ b/hosting/configuring-your-host/README.md
@@ -20,6 +20,14 @@ Go to `hostd`. If you're asked to unlock the UI, use your custom password if you
 
 ## Host
 
+### Port Forwarding
+
+`hostd` needs a stable internet connection and open network access in order to store and retrieve data on the Sia network. You will also need to forward the following ports so `hostd` can properly communicate with the network and renters.
+
+ * 9981/TCP (Sia Consensus)
+ * 9984/TCP (RHP4 - SiaMux)
+ * 9984/UDP (RHP4 - QUIC)
+
 ### Accepting contracts
 
 The **Accepting Contracts** setting determines whether your host will accept new contracts. Most hosts will always have this toggled on. However, if you want to exit the network, you can toggle this off to stop accepting new contracts. You must still fulfill any existing contracts before entirely shutting down your host.

--- a/hosting/setting-up-hostd/docker.md
+++ b/hosting/setting-up-hostd/docker.md
@@ -26,11 +26,11 @@ This guide will walk you through setting up `hostd` using Docker compose. At the
 
 To ensure you will not run into any issues with running `hostd` it is recommended your system meets the following requirements:
 
-* **Network Access:** `hostd` needs a stable internet connection and open network access in order to store and retrieve data on the Sia network. You will also need to forward the ports `9981-9984` so `hostd` can properly communicate with the network and renters.
 * **Hardware Requirements:** A stable setup that meets the following specifications is recommended. Not meeting these requirements may result in preventing slabs from uploading and can lead to a loss of data.
   - A quad-core CPU
   - 8GB of RAM
   - An SSD with at least 128GB of free space.
+  
 * **Software Requirements:** Before installing `hostd`, you will need to install [Docker](https://www.docker.com/get-started/).
 
 ## Create the compose file

--- a/hosting/setting-up-hostd/linux/debian.md
+++ b/hosting/setting-up-hostd/linux/debian.md
@@ -26,8 +26,6 @@ This guide will walk you through setting up `hostd` on Linux. At the end of this
 
 To ensure you will not run into any issues with running `hostd` it is recommended your system meets the following requirements:
 
-* **Network Access:** `hostd` needs a stable internet connection and open network access in order to store and retrieve data on the Sia network. You will also need to forward the ports `9981-9984` so `hostd` can properly communicate with the network and renters.
-
 * **Operating System Compatibility:** `hostd` is supported on the following Debian versions:
 	- Bookworm (Debian 12)
 	- Bullseye (Debian 11)

--- a/hosting/setting-up-hostd/linux/other.md
+++ b/hosting/setting-up-hostd/linux/other.md
@@ -23,7 +23,8 @@ This guide will walk you through setting up `hostd` on Linux. At the end of this
 
 ## Pre-requisites
 
-* **Network Access:** `hostd` needs a stable internet connection and open network access in order to store and retrieve data on the Sia network. You will also need to forward the ports `9981-9984` so `hostd` can properly communicate with the network and renters.
+To ensure you will not run into any issues with running `hostd` it is recommended your system meets the following requirements:
+
 * **Operating System Compatibility:** Ensure your Linux version is compatible with the `hostd` software. To do this, run  `uname -m` in your Terminal Emulator.
 
   * **x86\_64** - `Linux AMD64`

--- a/hosting/setting-up-hostd/linux/ubuntu.md
+++ b/hosting/setting-up-hostd/linux/ubuntu.md
@@ -26,8 +26,6 @@ This guide will walk you through setting up `hostd` on Linux. At the end of this
 
 To ensure you will not run into any issues with running `hostd` it is recommended your system meets the following requirements:
 
-* **Network Access:** `hostd` needs a stable internet connection and open network access in order to store and retrieve data on the Sia network. You will also need to forward the ports `9981-9984` so `hostd` can properly communicate with the network and renters.
-
 * **Operating System Compatibility:** `hostd` is supported on the following Ubuntu versions:
 	- Noble (Ubuntu 24.04)
 	- Mantic (Ubuntu 23.10)

--- a/hosting/setting-up-hostd/macos.md
+++ b/hosting/setting-up-hostd/macos.md
@@ -26,16 +26,18 @@ This guide will walk you through setting up `hostd` on macOS. At the end of this
 
 To ensure you will not run into any issues with running `hostd` it is recommended your system meets the following requirements:
 
-* **Network Access:** `hostd` needs a stable internet connection and open network access in order to store and retrieve data on the Sia network. You will also need to forward the ports `9981-9984` so `hostd` can properly communicate with the network and renters.
 * **Operating System Compatibility:** `hostd` is supported on the following macOS versions:
   * macOS 12: Monterey (Star)
   * macOS 13: Ventura (Rome)
   * macOS 14: Sonoma (Sunburst)
+
 * **System Updates:** Ensure that your macOS version is up to date with the latest system updates. These updates can contain important security fixes and improvements.
+
 * **Hardware Requirements:** A stable setup that meets the following specifications is recommended. Not meeting these requirements may result in preventing slabs from uploading and can lead to a loss of data.
   * A quad-core CPU
   * 8GB of RAM
   * An SSD with at least 128GB of free space.
+  
 * **Software Requirements:** Before installing `hostd`, you will need to install the [Homebrew](https://brew.sh) package manager. This will allow you to install and upgrade `hostd` easily.
 
 ## Installing `hostd`

--- a/hosting/setting-up-hostd/windows.md
+++ b/hosting/setting-up-hostd/windows.md
@@ -23,8 +23,8 @@ This guide will walk you through setting up `hostd` on Windows. At the end of th
 
 ## Pre-requisites
 
-* **Network Access:** `hostd` needs a stable internet connection and open network access in order to store and retrieve data on the Sia network. You will also need to forward the ports `9981-9984` so `hostd` can properly communicate with the network and renters.
 * **Operating System Compatibility:** Ensure your Windows version is compatible with the `hostd` software. Check [releases](../../miscellaneous/releases.md) supported by Windows versions.
+
 * **System Updates:** Ensure that your Windows is up to date with the latest system updates, as these updates can contain important security fixes and improvements.
 
 {% hint style="warning" %}


### PR DESCRIPTION
Removed port forwarding information from the individual setup docs and consolidated it under `Configuring your host`. This also includes the `UDP` requirement for port `9984`.