### PR TITLE
fix mailto link in exchanges doc

### DIFF
--- a/v2/exchanges.md
+++ b/v2/exchanges.md
@@ -1120,6 +1120,6 @@ To test your integration with `walletd` without risking real Siacoin, you can us
 
 Let us know!
 
-* Send us an [email](mailto://hello@sia.tech)
+* Send us an [email](mailto:hello@sia.tech)
 * [Reach out to the community on Discord](https://discord.gg/sia)
 * [Open an Issue](https://github.com/SiaFoundation/walletd)


### PR DESCRIPTION
## Summary
- fix malformed `mailto` link in `v2/exchanges.md`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b1bce1b328832a8e7d4e3ee8c5dcf3