### PR TITLE
“Announcing your Storage Node” (nodes’s → node’s)

### DIFF
--- a/hosting/announcing-your-host.md
+++ b/hosting/announcing-your-host.md
@@ -40,4 +40,4 @@ Once the announcement is confirmed, you can check if your storage node is visibl
 
 <figure><img src="../.gitbook/assets/siacentral.png" alt=""><figcaption><p>SiaCentral Troubleshooter</p></figcaption></figure>
 
-Enter your storage nodes's network address and click **Check Host**. This tool will connect to your storage node and notify you of any issues.
+Enter your storage node's network address and click **Check Host**. This tool will connect to your storage node and notify you of any issues.


### PR DESCRIPTION
Updates the Providing Storage → “Announcing your Storage Node” section to correct
“storage nodes’s network address” to “storage node’s network address”.

Fixes #147.
