### PR TITLE
remove stray “asdd” from Debian renterd install command

### DIFF
--- a/renting/setting-up-renterd/linux/debian.md
+++ b/renting/setting-up-renterd/linux/debian.md
@@ -78,7 +78,7 @@ Replace this part with the codename of the corresponding Debian release, such as
 sudo apt install renterd
 ```
 
-![](../../../.gitbook/assets/renterd-screenshots/install/linux/debian/02-renterd-debian-apt-install.png)
+![Installing renterd using apt install command on Debian](../../../.gitbook/assets/renterd-screenshots/install/linux/debian/02-renterd-debian-apt-install.png)
 
 **3. Verify `renterd` was installed successfully**
 


### PR DESCRIPTION
Removes the extra “asdd” from the Debian/Linux renterd install example under
Store Your Data → Installing renterd → Linux → Debian (step “2. Install renterd”),
so the command block shows only the valid command.

Fixes #151.
