### PR TITLE
Align macOS prerequisite wording with website

### DIFF
--- a/wallet/setting-up-walletd/macos.md
+++ b/wallet/setting-up-walletd/macos.md
@@ -24,6 +24,10 @@ This guide will walk you through setting up `walletd` on macOS. At the end of th
 * **Network Access:** `walletd` interacts with the Sia network, so you need a stable internet connection and open network access to connect to the Sia blockchain.
 * **Operating System Compatibility:** Ensure your macOS version is compatible with the `walletd` software. Check [releases](../../miscellaneous/releases.md) supported macOS versions.
 * **System Updates:** Ensure that your macOS is up to date with the latest system updates, as these updates can contain important security fixes and improvements.
+* **Hardware Requirements:** A stable setup that meets the following specifications is recommended.
+  * Quad-core processor
+  * 8GB RAM
+  * 256GB SSD for consensus data
 
 ## Getting `walletd`
 


### PR DESCRIPTION
The current macOS prerequisites on the site/docs are inconsistent and create ambiguity for users. 

Was missing: 
- quad-core processor
- 8GB RAM
- 256GB SSD for consensus data

fixes: #163 